### PR TITLE
fix: BaseMenu.jsx children may not have meta field when use hideChild…

### DIFF
--- a/src/components/RouteMenu/BaseMenu.jsx
+++ b/src/components/RouteMenu/BaseMenu.jsx
@@ -50,7 +50,7 @@ const renderMenuItem = (h, item, i18nRender) => {
     // 都给子菜单增加一个 hidden 属性
     // 用来给刷新页面时， selectedKeys 做控制用
     item.children.forEach(cd => {
-      cd.meta = Object.assign(cd.meta, { hidden: true })
+      cd.meta = Object.assign(cd.meta || {}, { hidden: true })
     })
   }
   return (


### PR DESCRIPTION
当使用`hideChildrenInMenu`选项来隐藏子菜单时，子路由如果不设置`meta`字段会导致报错，但是在隐藏子菜单时不给子路由设置`meta`是很常见的。