### PR TITLE
fix:formatRelativePath

### DIFF
--- a/src/utils/getMenuData.ts
+++ b/src/utils/getMenuData.ts
@@ -13,9 +13,6 @@ const formatRelativePath = (
 ): RouteRecordRaw[] => {
   // 计算路由绝对路径
   return routes.map(route => {
-    if (route.path.startsWith('/')) {
-      return route;
-    }
     if (parent) {
       route.path = `${parent.path || ''}/${route.path}`;
     } else {
@@ -24,7 +21,7 @@ const formatRelativePath = (
     route.path = route.path.replace('//', '/');
     // format children routes
     if (route.children && route.children.length > 0) {
-      route.children = formatRelativePath(route.children, route);
+      route.children = formatRelativePath(route.children, breadcrumb, route);
     }
     breadcrumb[`${route.path}`] = route;
     return route;


### PR DESCRIPTION
 这种情况会直接返回遍历不到children,另外递归遍历第二个参数穿错了~
```javascript
{
        path: '/about',
        name: 'About',
        meta: {
          title: "关于",
        },
        component: () => import(/* webpackChunkName: "about" */ '../views/About.vue'),
        children: [
          {
            path: '1',
            name: 'About1',
            meta: {
              title: "关于1",
            },
            component: () => import(/* webpackChunkName: "about" */ '../views/About.vue'),
          },
          {
            path: '2',
            name: 'About2',
            meta: {
              title: "关于2",
              hideInMenu: true
            },
            component: () => import(/* webpackChunkName: "about" */ '../views/About.vue'),
          },
        ]
      }
```