### PR TITLE
feat: fix LayoutHeader width bug collapsedWidth

### DIFF
--- a/packages/pro-layout/examples/layouts/BasicLayout.vue
+++ b/packages/pro-layout/examples/layouts/BasicLayout.vue
@@ -7,12 +7,19 @@
     :loading="loading"
     :breadcrumb="{ routes: breadcrumb }"
     style="min-height: 100vh"
+    :sider-width="220"
+    :collapsed-width="64"
     iconfont-url="//at.alicdn.com/t/font_2804900_nzigh7z84gc.js"
   >
     <template #menuHeaderRender>
       <a>
-        <img src="/favicon.svg" />
-        <h1>Pro Layout</h1>
+        <template v-if="baseState.collapsed">
+          <img src="https://procomponents.ant.design/favicon.ico" />
+        </template>
+        <template v-else>
+          <img src="/favicon.svg" />
+          <h1>Pro Layout</h1>
+        </template>
       </a>
     </template>
 

--- a/packages/pro-layout/src/Header.tsx
+++ b/packages/pro-layout/src/Header.tsx
@@ -90,7 +90,7 @@ export const HeaderView = defineComponent({
      */
     const width = computed(() => {
       return layout.value !== 'mix' && needSettingWidth.value
-        ? `calc(100% - ${props.collapsed ? 48 : props.siderWidth}px)`
+        ? `calc(100% - ${context.siderWidth}px)`
         : '100%';
     });
     const right = computed(() => (needFixedHeader.value ? 0 : undefined));

--- a/packages/pro-layout/src/components/SiderMenu/SiderMenu.tsx
+++ b/packages/pro-layout/src/components/SiderMenu/SiderMenu.tsx
@@ -158,7 +158,7 @@ const SiderMenu: FunctionalComponent<SiderMenuProps> = (props: SiderMenuProps) =
   const baseClassName = getPrefixCls('sider');
   const hasSplitMenu = computed(() => props.layout === 'mix' && props.splitMenus);
   const sTheme = computed(() => (props.layout === 'mix' && 'light') || props.navTheme);
-  const sSideWidth = computed(() => (props.collapsed ? props.collapsedWidth : props.siderWidth));
+  const sSideWidth = computed(() => context.siderWidth);
   const classNames = computed(() => {
     return {
       [baseClassName]: true,

--- a/packages/pro-layout/src/components/SiderMenu/index.less
+++ b/packages/pro-layout/src/components/SiderMenu/index.less
@@ -32,6 +32,7 @@
     position: relative;
     display: flex;
     align-items: center;
+    justify-content: center;
     padding: 16px 16px;
     cursor: pointer;
     transition: padding 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);


### PR DESCRIPTION
1. fix layout.header width bug on custom collapsedWidth
2. add `justify-content: center;` for  menu logo
3. update BasicLayout logo with `collapsed ` state