### PR TITLE
Feat/collapsed width

### DIFF
--- a/examples/src/layouts/BasicLayout.vue
+++ b/examples/src/layouts/BasicLayout.vue
@@ -7,7 +7,8 @@
     :handleMediaQuery="handleMediaQuery"
     :handleCollapse="handleCollapse"
     :i18nRender="i18nRender"
-    :siderWidth="208"
+    :siderWidth="240"
+    :collapsedWidth="64"
     v-bind="settings"
   >
     <!--

--- a/src/BasicLayout.jsx
+++ b/src/BasicLayout.jsx
@@ -55,10 +55,11 @@ const MediaQueryEnum = {
 const getPaddingLeft = (
   hasLeftPadding,
   collapsed = undefined,
+  collapsedWidth,
   siderWidth
 ) => {
   if (hasLeftPadding) {
-    return collapsed ? 80 : siderWidth
+    return collapsed ? collapsedWidth ? collapsedWidth: 80 : siderWidth
   }
   return 0
 }
@@ -83,6 +84,7 @@ const BasicLayout = {
       // theme,
       isMobile,
       collapsed,
+      collapsedWidth,
       mediaQuery,
       handleMediaQuery,
       handleCollapse,
@@ -132,7 +134,7 @@ const BasicLayout = {
             />
             <Layout class={[layout]} style={{
               paddingLeft: hasSiderMenu
-                ? `${getPaddingLeft(!!hasLeftPadding, collapsed, siderWidth)}px`
+                ? `${getPaddingLeft(!!hasLeftPadding, collapsed, collapsedWidth, siderWidth)}px`
                 : undefined,
               minHeight: '100vh'
             }}>

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -69,6 +69,7 @@ const HeaderView = {
       isMobile,
       layout,
       collapsed,
+      collapsedWidth,
       siderWidth,
       fixedHeader,
       autoHideHeader,
@@ -84,6 +85,8 @@ const HeaderView = {
       'ant-pro-top-menu': isTop,
     }
 
+    const calcWidth = collapsed ? collapsedWidth ? collapsedWidth: 80 : siderWidth
+
     // 没有 <></> 暂时代替写法
     return (
       visible ? (
@@ -93,7 +96,7 @@ const HeaderView = {
             style={{
               padding: 0,
               width: needSettingWidth
-                ? `calc(100% - ${collapsed ? 80 : siderWidth}px)`
+                ? `calc(100% - ${calcWidth}px)`
                 : '100%',
               zIndex: 9,
               right: fixedHeader ? 0 : undefined

--- a/src/components/RouteMenu/BaseMenu.jsx
+++ b/src/components/RouteMenu/BaseMenu.jsx
@@ -24,17 +24,17 @@ export const RouteMenuProps = {
 
 const httpReg = /(http|https|ftp):\/\/([\w.]+\/?)\S*/
 
-const renderMenu = (h, item, i18nRender) => {
+const renderMenu = (h, item, i18nRender, collapsed, collapsedWidth) => {
   if (item && !item.hidden) {
     const bool = item.children && !item.hideChildrenInMenu
-    return bool ? renderSubMenu(h, item, i18nRender) : renderMenuItem(h, item, i18nRender)
+    return bool ? renderSubMenu(h, item, i18nRender, collapsed, collapsedWidth) : renderMenuItem(h, item, i18nRender, collapsed, collapsedWidth)
   }
   return null
 }
 
-const renderSubMenu = (h, item, i18nRender) => {
+const renderSubMenu = (h, item, i18nRender, collapsed, collapsedWidth) => {
   return (
-    <SubMenu key={item.path} title={(
+    <SubMenu key={item.path} style={{marginLeft: calcMarginLeft(collapsed, collapsedWidth)}} title={(
       <span>
         {renderIcon(h, item.meta.icon)}
         <span>{renderTitle(h, item.meta.title, i18nRender)}</span>
@@ -45,7 +45,7 @@ const renderSubMenu = (h, item, i18nRender) => {
   )
 }
 
-const renderMenuItem = (h, item, i18nRender) => {
+const renderMenuItem = (h, item, i18nRender, collapsed, collapsedWidth) => {
   const meta = Object.assign({}, item.meta)
   const target = meta.target || null
   const hasRemoteUrl = httpReg.test(item.path)
@@ -61,13 +61,20 @@ const renderMenuItem = (h, item, i18nRender) => {
     })
   }
   return (
-    <MenuItem key={item.path}>
+    <MenuItem key={item.path} style={{marginLeft: calcMarginLeft(collapsed, collapsedWidth)}}>
       <CustomTag {...{ props, attrs }}>
         {renderIcon(h, meta.icon)}
         {renderTitle(h, meta.title, i18nRender)}
       </CustomTag>
     </MenuItem>
   )
+}
+
+const calcMarginLeft = (collapsed, collapsedWidth) => {
+  if (collapsed) {
+    return `-${collapsedWidth ? Math.abs(32 - (collapsedWidth - 16) / 2) : 0}px`
+  }
+  return 0
 }
 
 const renderIcon = (h, icon) => {
@@ -114,13 +121,6 @@ const RouteMenu = {
       return '100%'
     }
 
-    const calcMarginLeft = (collapsed, collapsedWidth) => {
-      if (collapsed) {
-        return `-${collapsedWidth ? Math.abs(32 - (collapsedWidth - 16) / 2) : 0}px`
-      }
-      return 0
-    }
-
     const dynamicProps = {
       props: {
         mode,
@@ -138,8 +138,7 @@ const RouteMenu = {
         openChange: handleOpenChange
       },
       style: {
-        width: calcWidth(collapsed, collapsedWidth),
-        marginLeft: calcMarginLeft(collapsed, collapsedWidth)
+        width: calcWidth(collapsed, collapsedWidth)
       }
     }
 
@@ -147,7 +146,7 @@ const RouteMenu = {
       if (item.hidden) {
         return null
       }
-      return renderMenu(h, item, i18nRender)
+      return renderMenu(h, item, i18nRender, collapsed, collapsedWidth)
     })
     return <Menu {...dynamicProps}>{menuItems}</Menu>
   },

--- a/src/components/RouteMenu/BaseMenu.jsx
+++ b/src/components/RouteMenu/BaseMenu.jsx
@@ -15,6 +15,7 @@ export const RouteMenuProps = {
   theme: PropTypes.string.def('dark'),
   mode: PropTypes.string.def('inline'),
   collapsed: PropTypes.bool.def(false),
+  collapsedWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).def(80),
   openKeys: PropTypes.array.def(undefined),
   selectedKeys: PropTypes.array.def(undefined),
   openOnceKey: PropTypes.bool.def(true),
@@ -94,7 +95,7 @@ const RouteMenu = {
     }
   },
   render (h, ctx) {
-    const { mode, theme, menus, i18nRender, openOnceKey } = this
+    const { mode, theme, menus, i18nRender, openOnceKey, collapsed, collapsedWidth } = this
     const handleOpenChange = (openKeys) => {
       // 在水平模式下时，不再执行后续
       if (mode === 'horizontal') {
@@ -105,6 +106,22 @@ const RouteMenu = {
       this.sOpenKeys = openKeys
       this.$emit('openChange', openKeys)
     }
+
+    const calcWidth = (collapsed, collapsedWidth) => {
+      if (collapsed) {
+        return `${collapsedWidth ? collapsedWidth: 80}px`
+      }
+      return '100%'
+    }
+
+    const calcMarginLeft = (collapsed, collapsedWidth) => {
+      if (collapsed) {
+        return `-${collapsedWidth ? Math.abs(32 - (collapsedWidth - 16) / 2) : 0}px`
+      }
+      return 0
+    }
+
+    console.log(calcMarginLeft(collapsed, collapsedWidth))
 
     const dynamicProps = {
       props: {
@@ -121,6 +138,10 @@ const RouteMenu = {
           }
         },
         openChange: handleOpenChange
+      },
+      style: {
+        width: calcWidth(collapsed, collapsedWidth),
+        marginLeft: calcMarginLeft(collapsed, collapsedWidth)
       }
     }
 

--- a/src/components/RouteMenu/BaseMenu.jsx
+++ b/src/components/RouteMenu/BaseMenu.jsx
@@ -121,8 +121,6 @@ const RouteMenu = {
       return 0
     }
 
-    console.log(calcMarginLeft(collapsed, collapsedWidth))
-
     const dynamicProps = {
       props: {
         mode,

--- a/src/components/SiderMenu/SiderMenu.jsx
+++ b/src/components/SiderMenu/SiderMenu.jsx
@@ -15,6 +15,7 @@ export const SiderMenuProps = {
   contentWidth: PropTypes.oneOf(['Fluid', 'Fixed']).def('Fluid'),
   collapsible: PropTypes.bool,
   collapsed: PropTypes.bool,
+  collapsedWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).def(80),
   openKeys: PropTypes.array.def(undefined),
   selectedKeys: PropTypes.array.def(undefined),
   openOnceKey: PropTypes.bool.def(true),
@@ -71,6 +72,14 @@ export const defaultRenderLogoAntTitle = (h, props) => {
   )
 }
 
+const adaptWidth = collapsedWidth => {
+  if (collapsedWidth >= 32 && collapsedWidth <= 80) {
+    return collapsedWidth
+  } else {
+    return 80
+  }
+}
+
 const SiderMenu = {
   name: 'SiderMenu',
   model: {
@@ -82,6 +91,7 @@ const SiderMenu = {
     const {
       collapsible,
       collapsed,
+      collapsedWidth,
 
       selectedKeys,
       openKeys,
@@ -114,6 +124,14 @@ const SiderMenu = {
       logo, title, menuHeaderRender, collapsed
     })
 
+    // 用户的logo图片宽度无法动态获取，暂时写死32，后续有更好的方案再修改
+    const logoPaddingLeft = (collapsed, collapsedWidth) => {
+      if (collapsed) {
+        return `${collapsedWidth ? Math.abs((collapsedWidth - 32) / 2) : 0}px`
+      }
+      return 32
+    }
+
     return (<Sider
       class={siderCls}
       breakpoint={'lg'}
@@ -122,11 +140,13 @@ const SiderMenu = {
       theme={theme}
       collapsible={collapsible}
       collapsed={collapsed}
+      collapsedWidth={adaptWidth(collapsedWidth)}
     >
       {headerDom && (
         <div
           class="ant-pro-sider-menu-logo"
           onClick={onMenuHeaderClick}
+          style={{paddingLeft: logoPaddingLeft(collapsed, adaptWidth(collapsedWidth))}}
           id="logo"
         >
           <router-link to={{ path: '/' }}>
@@ -141,6 +161,7 @@ const SiderMenu = {
       ) || (
         <BaseMenu
           collapsed={collapsed}
+          collapsedWidth={adaptWidth(collapsedWidth)}
           openKeys={openKeys}
           selectedKeys={selectedKeys}
           openOnceKey={openOnceKey}


### PR DESCRIPTION
### 变动性质

新特性提交

### 需求背景

侧边栏siderMenu业务部门想要自定义收缩宽度，因此新增此功能。

### 实现方案

增加新属性collapsedWidth

### 功能备注

考虑到美观和通用实现。目前只能在[32, 80]范围，即logo图片宽度到默认80之间。超出此范围默认改为80。

### 使用范例

```
<pro-layout
    :menus="menus"
    :collapsed="collapsed"
    :mediaQuery="query"
    :isMobile="isMobile"
    :handleMediaQuery="handleMediaQuery"
    :handleCollapse="handleCollapse"
    :i18nRender="i18nRender"
    :siderWidth="240"
    :collapsedWidth="64"
    v-bind="settings"
  />
```