### PR TITLE
fix (pro-layout/src/utils/isImg): 修改判断是否是图片链接的工具函数

### DIFF
--- a/packages/pro-layout/src/utils/isImg/index.ts
+++ b/packages/pro-layout/src/utils/isImg/index.ts
@@ -2,7 +2,7 @@
 
 /** 判断是否是图片链接 */
 function isImg(path: string): boolean {
-  return /\w.(png|jpg|jpeg|svg|webp|gif|bmp)$/i.test(path);
+  return /[^\\\/\:\*\?\"\<\>|]+.(png|jpg|jpeg|svg|webp|gif|bmp)$/i.test(path);
 }
 
 export default isImg;


### PR DESCRIPTION
原正则表达式中 `\w.(png|jpg|jpeg|svg|webp|gif|bmp)$` 只能匹配诸如 `a.png` 此种形式，对于 `ab.png` 或者更复杂的形式则无法匹配