### PR TITLE
fix(@ant-design-vue/pro-table): slots, styles, types, docs & examples

### DIFF
--- a/packages/pro-table/README.md
+++ b/packages/pro-table/README.md
@@ -37,26 +37,27 @@ ProTable puts a layer of wrapping on top of antd's Table, supports some presets,
   request={async (
     // The first parameter params is the combination of the query form and params parameters
     // The first parameter will always have pageSize and current, which are antd specifications
-    params: T & {
-      pageSize: number;
-      current: number;
-    },
+    { current, pageSize, ...params },
     sort,
     filter,
   ) => {
     // Here you need to return a Promise, and you can transform the data before returning it
     // If you need to transform the parameters you can change them here
-    const payload = await axios.get('//api', {
-      page: params.current,
-      pageSize: params.pageSize,
+    const {
+      data: { result: data, total },
+    } = await axios.get<{
+      result: Record<string, unknown>[];
+      total: number;
+    }>('/api', {
+      params: { page: current, pageSize, ...params },
     });
     return {
-      data: payload.result,
+      data,
+      // not passed will use the length of the data, if it is paged you must pass
+      total,
       // Please return true for success.
       // otherwise the table will stop parsing the data, even if there is data
-      success: boolean,
-      // not passed will use the length of the data, if it is paged you must pass
-      total: number,
+      success: true,
     };
   }}
 />
@@ -75,17 +76,17 @@ ProTable puts a layer of wrapping on top of antd's Table, supports some presets,
 
 ### Slots
 
-| Name     | Description                                              | Tag             |
-| -------- | -------------------------------------------------------- | --------------- |
-| actions  | Render toolbar actions area                              | v-slot:actions  |
+| Name | Description | Tag |
+| --- | --- | --- |
+| actions | Render toolbar actions area | v-slot:actions |
 | settings | Render toolbar settings area, will overwrite the options | v-slot:settings |
 
 ### Events
 
-| Name         | Description                                                             | Arguments                   |
-| ------------ | ----------------------------------------------------------------------- | --------------------------- |
-| load         | Triggered after the data is loaded, it will be triggered multiple times | `(dataSource: T[]) => void` |
-| requestError | Triggered when data loading fails                                       | `(error: Error) => void`    |
+| Name | Description | Arguments |
+| --- | --- | --- |
+| load | Triggered after the data is loaded, it will be triggered multiple times | `(dataSource: T[]) => void` |
+| requestError | Triggered when data loading fails | `(error: Error) => void` |
 
 ### ListToolbar
 
@@ -95,24 +96,24 @@ Toolbar section for customizing forms.
 
 Toolbar configuration properties for lists and tables
 
-| Parameters   | Description                                              | Type                            | Default |
-| ------------ | -------------------------------------------------------- | ------------------------------- | ------- |
-| title        | title                                                    | `not implemented`               | -       |
-| subTitle     | subTitle                                                 | `not implemented`               | -       |
-| description  | description                                              | `not implemented`               | -       |
-| search       | query area                                               | `not implemented`               | -       |
-| actions      | actions area                                             | `false \| VNode[]`              | -       |
-| settings     | settings area                                            | `false \| (VNode \| Setting)[]` | -       |
-| filter       | The filter area, usually used with `LightFilter`         | `not implemented`               | -       |
-| multipleLine | Whether to display multiple lines                        | `not implemented`               | -       |
-| menu         | menu configuration                                       | `not implemented`               | -       |
-| tabs         | Tabs configuration, only valid if `multipleLine` is true | `not implemented`               | -       |
+| Parameters | Description | Type | Default |
+| --- | --- | --- | --- |
+| title | title | `not implemented` | - |
+| subTitle | subTitle | `not implemented` | - |
+| description | description | `not implemented` | - |
+| search | query area | `not implemented` | - |
+| actions | actions area | `false \| VNode[]` | - |
+| settings | settings area | `false \| (VNode \| Setting)[]` | - |
+| filter | The filter area, usually used with `LightFilter` | `not implemented` | - |
+| multipleLine | Whether to display multiple lines | `not implemented` | - |
+| menu | menu configuration | `not implemented` | - |
+| tabs | Tabs configuration, only valid if `multipleLine` is true | `not implemented` | - |
 
 #### Setting
 
-| Parameters | Description                 | Type                  | Default |
-| ---------- | --------------------------- | --------------------- | ------- |
-| icon       | icon                        | `ReactNode`           | -       |
-| tooltip    | tooltip Description         | `string`              | -       |
-| key        | operation unique identifier | `string`              | -       |
-| onClick    | set to be triggered         | `(key: string)=>void` | -       |
+| Parameters | Description | Type | Default |
+| --- | --- | --- | --- |
+| icon | icon | `ReactNode` | - |
+| tooltip | tooltip Description | `string` | - |
+| key | operation unique identifier | `string` | - |
+| onClick | set to be triggered | `(key: string)=>void` | - |

--- a/packages/pro-table/README.zh-CN.md
+++ b/packages/pro-table/README.zh-CN.md
@@ -37,26 +37,27 @@ ProTable 在 antd 的 Table 上进行了一层封装，支持了一些预设，�
   request={async (
     // 第一个参数 params 查询表单和 params 参数的结合
     // 第一个参数中一定会有 pageSize 和  current ，这两个参数是 antd 的规范
-    params: T & {
-      pageSize: number;
-      current: number;
-    },
+    { current, pageSize, ...params },
     sort,
     filter,
   ) => {
     // 这里需要返回一个 Promise,在返回之前你可以进行数据转化
     // 如果需要转化参数可以在这里进行修改
-    const payload = await axios.get('//api', {
-      page: params.current,
-      pageSize: params.pageSize,
+    const {
+      data: { result: data, total },
+    } = await axios.get<{
+      result: Record<string, unknown>[];
+      total: number;
+    }>('/api', {
+      params: { page: current, pageSize, ...params },
     });
     return {
-      data: payload.result,
+      data,
+      // 不传会使用 data 的长度，如果是分页一定要传
+      total,
       // success 请返回 true，
       // 不然 table 会停止解析数据，即使有数据
-      success: boolean,
-      // 不传会使用 data 的长度，如果是分页一定要传
-      total: number,
+      success: true,
     };
   }}
 />
@@ -82,10 +83,10 @@ ProTable 在 antd 的 Table 上进行了一层封装，支持了一些预设，�
 
 ### 事件
 
-| 名称         | 说明                          | 参数                        |
-| ------------ | ----------------------------- | --------------------------- |
-| load         | 数据加载完成后触发,会多次触发 | `(dataSource: T[]) => void` |
-| requestError | 数据加载失败时触发            | `(error: Error) => void`    |
+| 名称 | 说明 | 参数 |
+| --- | --- | --- |
+| load | 数据加载完成后触发,会多次触发 | `(dataSource: T[]) => void` |
+| requestError | 数据加载失败时触发 | `(error: Error) => void` |
 
 ### 列表工具栏
 
@@ -93,18 +94,18 @@ ProTable 在 antd 的 Table 上进行了一层封装，支持了一些预设，�
 
 #### ListToolBarProps
 
-| 参数         | 说明                                           | 类型                              | 默认值  |
-| ------------ | ---------------------------------------------- | --------------------------------- | ------- |
-| title        | 标题                                           | `尚未实现`                        | -       |
-| subTitle     | 子标题                                         | `尚未实现`                        | -       |
-| description  | 描述                                           | `尚未实现`                        | -       |
-| search       | 查询区                                         | `尚未实现`                        | -       |
-| actions      | 操作区                                         | `false \| VueNode[]`              | -       |
-| settings     | 设置区                                         | `false \| (VueNode \| Setting)[]` | -       |
-| filter       | 过滤区，通常配合 `LightFilter` 使用            | `尚未实现`                        | -       |
-| multipleLine | 是否多行展示                                   | `尚未实现`                        | `false` |
-| menu         | 菜单配置                                       | `尚未实现`                        | -       |
-| tabs         | 标签页配置，仅当 `multipleLine` 为 true 时有效 | `尚未实现`                        | -       |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| title | 标题 | `尚未实现` | - |
+| subTitle | 子标题 | `尚未实现` | - |
+| description | 描述 | `尚未实现` | - |
+| search | 查询区 | `尚未实现` | - |
+| actions | 操作区 | `false \| VueNode[]` | - |
+| settings | 设置区 | `false \| (VueNode \| Setting)[]` | - |
+| filter | 过滤区，通常配合 `LightFilter` 使用 | `尚未实现` | - |
+| multipleLine | 是否多行展示 | `尚未实现` | `false` |
+| menu | 菜单配置 | `尚未实现` | - |
+| tabs | 标签页配置，仅当 `multipleLine` 为 true 时有效 | `尚未实现` | - |
 
 #### Setting
 

--- a/packages/pro-table/examples/views/ProTable.vue
+++ b/packages/pro-table/examples/views/ProTable.vue
@@ -1,5 +1,7 @@
 <script lang="ts" setup>
 import ProTable, { type ProColumnsType } from '@ant-design-vue/pro-table';
+import { PlusOutlined } from '@ant-design/icons-vue';
+import { Button as AButton } from 'ant-design-vue';
 import axios from 'axios';
 
 const columns: ProColumnsType = [
@@ -57,36 +59,34 @@ const columns: ProColumnsType = [
 const request = async ({
   current,
   pageSize,
-  ...others
+  ...params
 }: {
   current: number;
   pageSize: number;
   [key: string]: unknown;
 }) => {
   const {
-    data: { results },
+    data: { results: data },
   } = await axios.get<{
     results: Record<string, unknown>[];
   }>('https://randomuser.me/api?noinfo', {
-    params: {
-      results: pageSize,
-      page: current,
-      ...others,
-    },
+    params: { page: current, results: pageSize, ...params },
   });
   return {
-    data: results,
+    data,
     total: 200,
+    success: true,
   };
 };
 </script>
 <template>
-  <pro-table
-    :columns="columns"
-    :row-key="record => record.login.uuid"
-    :request="request"
-    :options="{ density: true, fullScreen: true }"
-  >
+  <pro-table :columns="columns" :row-key="record => record.login.uuid" :request="request">
+    <template #actions>
+      <a-button key="button" type="primary">
+        <template #icon><PlusOutlined /></template>
+        新建
+      </a-button>
+    </template>
     <template #bodyCell="{ column, text }">
       <template v-if="column.dataIndex === 'name'">{{ text.first }} {{ text.last }}</template>
     </template>

--- a/packages/pro-table/src/Table.less
+++ b/packages/pro-table/src/Table.less
@@ -1,0 +1,67 @@
+@import (reference) './default.less';
+
+@import 'ant-design-vue/es/table/style/index.less';
+@import 'ant-design-vue/es/card/style/index.less';
+
+.pro-table-tooltip-text span {
+  color: @component-background;
+}
+
+.@{pro-table-prefix-cls} {
+  z-index: 1;
+
+  &:not(:root):fullscreen {
+    min-height: 100vh;
+    overflow: auto;
+    background: @component-background;
+  }
+
+  &-extra {
+    margin-bottom: 16px;
+  }
+
+  &-polling {
+    .@{pro-table-prefix-cls}-list-toolbar-setting-item {
+      .anticon.anticon-reload {
+        transform: rotate(0deg);
+        animation: turn 1s linear infinite;
+      }
+    }
+  }
+
+  td.@{ant-prefix}-table-cell {
+    > a {
+      font-size: @font-size-base;
+    }
+  }
+
+  .@{ant-prefix}-table .@{ant-prefix}-table-tbody .@{ant-prefix}-table-wrapper:only-child .@{ant-prefix}-table {
+    margin: 0;
+  }
+
+  .@{ant-prefix}-table.@{ant-prefix}-table-middle .@{pro-table-prefix-cls} {
+    margin: -12px -8px;
+  }
+}
+
+@keyframes turn {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  25% {
+    transform: rotate(90deg);
+  }
+
+  50% {
+    transform: rotate(180deg);
+  }
+
+  75% {
+    transform: rotate(270deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/pro-table/src/components/Alert/index.less
+++ b/packages/pro-table/src/components/Alert/index.less
@@ -1,5 +1,7 @@
-@root-entry-name: 'default';
-@import (reference) 'ant-design-vue/es/style/themes/index.less';
+@import (reference) '../../default.less';
+
+@import 'ant-design-vue/es/alert/style/index.less';
+@import 'ant-design-vue/es/space/style/index.less';
 
 @pro-table-alert-prefix-cls: ~'@{ant-prefix}-pro-table-alert';
 

--- a/packages/pro-table/src/components/Alert/index.tsx
+++ b/packages/pro-table/src/components/Alert/index.tsx
@@ -1,9 +1,7 @@
 import type { FunctionalComponent } from 'vue';
-import { Alert, Space } from 'ant-design-vue';
 import { useSharedContext } from '../../shared/Context';
+import { Alert, Space } from 'ant-design-vue';
 
-import 'ant-design-vue/es/alert/style';
-import 'ant-design-vue/es/space/style';
 import './index.less';
 
 type TableAlertProps = {

--- a/packages/pro-table/src/components/Form/index.less
+++ b/packages/pro-table/src/components/Form/index.less
@@ -1,7 +1,4 @@
-@root-entry-name: 'default';
-@import (reference) 'ant-design-vue/es/style/themes/index.less';
-@import (reference) 'ant-design-vue/es/style/mixins/index.less';
-@import (reference) '../../index.less';
+@import (reference) '../../default.less';
 
 @pro-table-search-prefix-cls: ~'@{ant-prefix}-pro-table-search';
 

--- a/packages/pro-table/src/components/Form/index.tsx
+++ b/packages/pro-table/src/components/Form/index.tsx
@@ -1,6 +1,6 @@
 import { defineComponent, reactive, computed, toRaw, type PropType } from 'vue';
-import { QueryFilter, queryFilterProps, ProFormText } from '@ant-design-vue/pro-form';
 import { useSharedContext } from '../../shared/Context';
+import { QueryFilter, queryFilterProps, ProFormText } from '@ant-design-vue/pro-form';
 import type { ProColumnsType, ProColumnType } from '../../typings';
 
 import './index.less';

--- a/packages/pro-table/src/components/ListToolBar/index.less
+++ b/packages/pro-table/src/components/ListToolBar/index.less
@@ -1,5 +1,7 @@
-@root-entry-name: 'default';
-@import (reference) 'ant-design-vue/es/style/themes/index.less';
+@import (reference) '../../default.less';
+
+@import 'ant-design-vue/es/space/style/index.less';
+@import 'ant-design-vue/es/tooltip/style/index.less';
 
 @pro-list-toolbar: ~'@{ant-prefix}-pro-table-list-toolbar';
 

--- a/packages/pro-table/src/components/ListToolBar/index.tsx
+++ b/packages/pro-table/src/components/ListToolBar/index.tsx
@@ -1,11 +1,9 @@
 import { isVNode, type FunctionalComponent, type VNode } from 'vue';
-import { Space, Tooltip } from 'ant-design-vue';
 import { useSharedContext } from '../../shared/Context';
+import { Space, Tooltip } from 'ant-design-vue';
 import { getSlotVNode } from '@ant-design-vue/pro-utils';
 import type { WithFalse } from '../../typings';
 
-import 'ant-design-vue/es/space/style';
-import 'ant-design-vue/es/tooltip/style';
 import './index.less';
 
 export type ListToolBarSetting = {

--- a/packages/pro-table/src/components/ToolBar/ColumnSetting/index.less
+++ b/packages/pro-table/src/components/ToolBar/ColumnSetting/index.less
@@ -1,5 +1,10 @@
-@root-entry-name: 'default';
-@import (reference) 'ant-design-vue/es/style/themes/index.less';
+@import (reference) '../../../default.less';
+
+@import 'ant-design-vue/es/checkbox/style/index.less';
+@import 'ant-design-vue/es/space/style/index.less';
+@import 'ant-design-vue/es/popover/style/index.less';
+@import 'ant-design-vue/es/tree/style/index.less';
+@import 'ant-design-vue/es/tooltip/style/index.less';
 
 @pro-column-setting-prefix-cls: ~'@{ant-prefix}-pro-table-column-setting';
 

--- a/packages/pro-table/src/components/ToolBar/ColumnSetting/index.tsx
+++ b/packages/pro-table/src/components/ToolBar/ColumnSetting/index.tsx
@@ -1,4 +1,5 @@
 import type { FunctionalComponent, VNodeChild } from 'vue';
+import { useSharedContext } from '../../../shared/Context';
 import { Checkbox, Space, Popover, Tree, Tooltip } from 'ant-design-vue';
 import {
   HolderOutlined,
@@ -7,7 +8,6 @@ import {
   VerticalAlignMiddleOutlined,
   VerticalAlignBottomOutlined,
 } from '@ant-design/icons-vue';
-import { useSharedContext } from '../../../shared/Context';
 import { genColumnKey } from '../../../utils';
 import { omit } from 'lodash-es';
 import type { DataNode } from 'ant-design-vue/es/tree';
@@ -18,12 +18,6 @@ import type {
   ProColumnsType,
   ColumnState,
 } from '../../../typings';
-
-import 'ant-design-vue/es/checkbox/style';
-import 'ant-design-vue/es/space/style';
-import 'ant-design-vue/es/popover/style';
-import 'ant-design-vue/es/tree/style';
-import 'ant-design-vue/es/tooltip/style';
 
 import './index.less';
 
@@ -292,6 +286,8 @@ const ColumnSetting: FunctionalComponent<ColumnSettingProps> = (props, { slots }
   const { columns, checkable = true, checkedReset = true, draggable = true, listsHeight, extra } = props;
 
   const { columnsMap = {}, setColumnsMap, getMessage: t, getPrefixCls } = useSharedContext();
+
+  console.log('ColumnSetting.columnsMap', columnsMap);
 
   const localColumns: LocalColumns = columns;
 

--- a/packages/pro-table/src/components/ToolBar/Density.tsx
+++ b/packages/pro-table/src/components/ToolBar/Density.tsx
@@ -1,7 +1,7 @@
 import { defineComponent, shallowReactive, watch, watchEffect } from 'vue';
+import { useSharedContext } from '../../shared/Context';
 import { Dropdown, Menu, Tooltip } from 'ant-design-vue';
 import { ColumnHeightOutlined } from '@ant-design/icons-vue';
-import { useSharedContext } from '../../shared/Context';
 import type { SizeType } from '../../typings';
 
 const { Item } = Menu;

--- a/packages/pro-table/src/components/ToolBar/Fullscreen.tsx
+++ b/packages/pro-table/src/components/ToolBar/Fullscreen.tsx
@@ -1,7 +1,7 @@
 import { defineComponent, shallowReactive, watchPostEffect } from 'vue';
+import { useSharedContext } from '../../shared/Context';
 import { Tooltip } from 'ant-design-vue';
 import { FullscreenOutlined, FullscreenExitOutlined } from '@ant-design/icons-vue';
-import { useSharedContext } from '../../shared/Context';
 
 import 'ant-design-vue/es/tooltip/style';
 

--- a/packages/pro-table/src/components/ToolBar/index.less
+++ b/packages/pro-table/src/components/ToolBar/index.less
@@ -1,6 +1,4 @@
-@root-entry-name: 'default';
-@import (reference) 'ant-design-vue/es/style/themes/index.less';
-@import '../../index';
+@import (reference) '../../default.less';
 
 .@{pro-table-prefix-cls}-toolbar {
   display: flex;

--- a/packages/pro-table/src/components/ToolBar/index.tsx
+++ b/packages/pro-table/src/components/ToolBar/index.tsx
@@ -1,10 +1,10 @@
 import type { FunctionalComponent, VNode } from 'vue';
+import { useSharedContext } from '../../shared/Context';
 import ListToolBar, { type ListToolBarSetting, type ListToolBarProps } from '../ListToolBar';
 import { ReloadOutlined } from '@ant-design/icons-vue';
 import Density from './Density';
 import ColumnSetting from './ColumnSetting';
 import Fullscreen from './Fullscreen';
-import { useSharedContext } from '../../shared/Context';
 import type { InputProps } from 'ant-design-vue';
 import type { WithFalse } from '../../typings';
 
@@ -42,7 +42,7 @@ export type ToolBarProps = {
   toolbar?: WithFalse<ListToolBarProps>;
 };
 
-const ToolBar: FunctionalComponent<ToolBarProps> = ({ columns = [], toolbar, options: propsOptions }) => {
+const ToolBar: FunctionalComponent<ToolBarProps> = ({ columns = [], toolbar, options: propsOptions }, { slots }) => {
   const { actionRef, getMessage: t } = useSharedContext();
 
   if (toolbar === false) return null;
@@ -72,7 +72,7 @@ const ToolBar: FunctionalComponent<ToolBarProps> = ({ columns = [], toolbar, opt
         .map(key => catalog[key])
     : [];
 
-  return <ListToolBar settings={settings} {...toolbar} />;
+  return <ListToolBar settings={settings} {...toolbar} v-slots={slots} />;
 };
 
 export default ToolBar;

--- a/packages/pro-table/src/default.less
+++ b/packages/pro-table/src/default.less
@@ -1,0 +1,6 @@
+@root-entry-name: 'default';
+
+@import (reference) 'ant-design-vue/es/style/themes/index.less';
+@import (reference) 'ant-design-vue/es/style/mixins/index.less';
+
+@pro-table-prefix-cls: ~'@{ant-prefix}-pro-table';

--- a/packages/pro-table/src/hooks/useFetchData.ts
+++ b/packages/pro-table/src/hooks/useFetchData.ts
@@ -106,7 +106,7 @@ export const useFetchData = <T>(
     }
   };
 
-  // If `request` is undefined, relinquish the control of `loading`, `dataSource`, `pagination`.
+  // If `request` is undefined, release the control of `loading`, `dataSource`, `pagination`.
   watchEffect(() => {
     getData === undefined &&
       Object.assign(
@@ -135,7 +135,7 @@ export const useFetchData = <T>(
     { immediate: true },
   );
 
-  watch([state.params, queryFilter], async (current, previous) => {
+  watch([() => state.params, queryFilter], async (current, previous) => {
     if (!isEqual(current, previous)) {
       setPageInfo({ current: 1 });
       await fetchData();

--- a/packages/pro-table/src/index.ts
+++ b/packages/pro-table/src/index.ts
@@ -2,6 +2,7 @@ import type { App } from 'vue';
 import ProTable from './Table';
 import EditableProTable from './components/EditableTable';
 
+import './default.less';
 import './style.less';
 
 export type { ProColumnType, ProColumnGroupType, ProColumnsType, ProTableProps, ResponseData } from './typings';

--- a/packages/pro-table/src/style.less
+++ b/packages/pro-table/src/style.less
@@ -1,2 +1,9 @@
-@import "./index.less";
-// @import '@ant-design-vue/pro-form/dist/style.less'; // pro-form css or style.less
+@import './default.less';
+
+@import './Table.less';
+@import './components/Alert/index.less';
+@import './components/Form/index.less';
+@import './components/ToolBar/ColumnSetting/index.less';
+@import './components/ToolBar/index.less';
+@import './components/ListToolBar/index.less';
+

--- a/packages/pro-table/src/typings.ts
+++ b/packages/pro-table/src/typings.ts
@@ -27,11 +27,11 @@ export type ProColumnType<RecordType> = ColumnType<RecordType> & {
   search?: boolean;
 };
 
-export type ProColumnGroupType<RecordType> = Omit<ProColumnType<RecordType>, 'dataIndex'> & {
+export type ProColumnGroupType<RecordType extends DefaultRecordType> = Omit<ProColumnType<RecordType>, 'dataIndex'> & {
   chilren: ProColumnsType<RecordType>;
 };
 
-export type ProColumnsType<RecordType = DefaultRecordType> = (
+export type ProColumnsType<RecordType extends DefaultRecordType = DefaultRecordType> = (
   | ProColumnGroupType<RecordType>
   | ProColumnType<RecordType>
 )[];
@@ -57,6 +57,7 @@ export type FetchData<RecordType> = (
 
 export type ProTableProps<RecordType extends DefaultRecordType = DefaultRecordType> = TableProps<RecordType> &
   Partial<{
+    editable: boolean;
     columns: ProColumnsType<RecordType>;
     request: FetchData<RecordType>;
     params: Record<string, unknown>;


### PR DESCRIPTION
修复插槽失效，修复antv按需引入时，ProTable样式丢失的问题，修复一些类型错误，移除useFetchData引发的警告，修正README中的request范例，并在examples中更新示例。