### PR TITLE
feat(@ant-design-vue/pro-layout): Header样式调整和Tab标签页插槽

### DIFF
--- a/docs/components/pro-layout.md
+++ b/docs/components/pro-layout.md
@@ -118,13 +118,15 @@ const layoutConf = reactive({
 | menuHeaderRender        | render header logo and title                                          | v-slot \| VNode \| (logo,title)=>VNode \| false                        | -                  |
 | menuExtraRender         | render extra menu item                                                | v-slot \| VNode \| (props)=>VNode \| false                             | -                  |
 | menuFooterRender        | render footer menu item                                               | v-slot \| VNode \| (props)=>VNode \| false                             | -                  |
-| headerContentRender     | custom header render method                                           | `slot` \| (props: BasicLayoutProps) => VNode                           | -                  |
-| rightContentRender      | header right content render method                                    | `slot` \| (props: HeaderViewProps) => VNode                            | -                  |
-| collapsedButtonRender   | custom collapsed button method                                        | `slot` \| (collapsed: boolean) => VNode                                | -                  |
-| footerRender            | custom footer render method                                           | `slot` \| (props: BasicLayoutProps) => VNode                           | `false`            |
-| breadcrumbRender        | custom breadcrumb render method                                       | `slot` \| ({ route, params, routes, paths, h }) => VNode[]             | -                  |
 | menuItemRender          | custom render Menu.Item                                               | v-slot#menuItemRender="{ item, icon }" \| ({ item, icon }) => VNode    | null               |
 | subMenuItemRender       | custom render Menu.SubItem                                            | v-slot#subMenuItemRender="{ item, icon }" \| ({ item, icon }) => VNode | null               |
+| collapsedButtonRender   | custom collapsed button method                                        | `slot` \| (collapsed: boolean) => VNode                                | -                  |
+| headerRender            | custom header render method                                           | `slot` \| (props: BasicLayoutProps) => VNode                           | -                  |
+| headerContentRender     | header content render method only layout side                         | `slot` \| (props: BasicLayoutProps) => VNode                           | -                  |
+| rightContentRender      | header right content render method                                    | `slot` \| (props: BasicLayoutProps) => VNode                           | -                  |
+| footerRender            | custom footer render method                                           | `slot` \| (props: BasicLayoutProps) => VNode                           | `false`            |
+| tabRender               | custom tab render method                                              | `slot` \| ({ width, ...BasicLayoutProps }) => VNode                    | `false`            |
+| breadcrumbRender        | custom breadcrumb render method                                       | `slot` \| ({ route, params, routes, paths, h }) => VNode[]             | -                  |
 | locale                  | i18n                                                                  | Function (key: string) => string \| `false`                            | `false`            |
 
 > Menu generation requires `getMenuData` and `clearMenuItem` function
@@ -233,6 +235,38 @@ const layoutConf = reactive({
 <template #collapsedButtonRender="collapsed">
   <HeartOutlined v-if="collapsed" />
   <SmileOutlined v-else />
+</template>
+```
+
+#### Custom tabRender
+
+```vue
+<template #tabRender="{ width, fixedHeader }">
+  <div>
+    <header
+      class="ant-layout-header"
+      style="height: 36px; line-height: 36px; background: transparent"
+      v-if="fixedHeader"
+    ></header>
+    <div
+      :style="{
+        margin: '0',
+        height: '36px',
+        lineHeight: '36px',
+        right: '0px',
+        top: '48px',
+        position: fixedHeader ? 'fixed' : 'unset',
+        zIndex: 14,
+        padding: '4px 16px',
+        width: width,
+        background: '#fff',
+        boxShadow: '0 1px 4px #0015291f',
+        transition: 'background 0.3s, width 0.2s',
+      }"
+    >
+      tabRender fixedHeader：{{fixedHeader}} width：{{ width }} 
+    </div>
+  </div>
 </template>
 ```
 

--- a/packages/pro-layout/README.md
+++ b/packages/pro-layout/README.md
@@ -114,13 +114,15 @@ const layoutConf = reactive({
 | menuHeaderRender        | render header logo and title                                          | v-slot \| VNode \| (logo,title)=>VNode \| false                        | -                  |
 | menuExtraRender         | render extra menu item                                                | v-slot \| VNode \| (props)=>VNode \| false                             | -                  |
 | menuFooterRender        | render footer menu item                                               | v-slot \| VNode \| (props)=>VNode \| false                             | -                  |
-| headerContentRender     | custom header render method                                           | `slot` \| (props: BasicLayoutProps) => VNode                           | -                  |
-| rightContentRender      | header right content render method                                    | `slot` \| (props: HeaderViewProps) => VNode                            | -                  |
-| collapsedButtonRender   | custom collapsed button method                                        | `slot` \| (collapsed: boolean) => VNode                                | -                  |
-| footerRender            | custom footer render method                                           | `slot` \| (props: BasicLayoutProps) => VNode                           | `false`            |
-| breadcrumbRender        | custom breadcrumb render method                                       | `slot` \| ({ route, params, routes, paths, h }) => VNode[]             | -                  |
 | menuItemRender          | custom render Menu.Item                                               | v-slot#menuItemRender="{ item, icon }" \| ({ item, icon }) => VNode    | null               |
 | subMenuItemRender       | custom render Menu.SubItem                                            | v-slot#subMenuItemRender="{ item, icon }" \| ({ item, icon }) => VNode | null               |
+| collapsedButtonRender   | custom collapsed button method                                        | `slot` \| (collapsed: boolean) => VNode                                | -                  |
+| headerRender            | custom header render method                                           | `slot` \| (props: BasicLayoutProps) => VNode                           | -                  |
+| headerContentRender     | header content render method only layout side                         | `slot` \| (props: BasicLayoutProps) => VNode                           | -                  |
+| rightContentRender      | header right content render method                                    | `slot` \| (props: BasicLayoutProps) => VNode                           | -                  |
+| footerRender            | custom footer render method                                           | `slot` \| (props: BasicLayoutProps) => VNode                           | `false`            |
+| tabRender               | custom tab render method                                              | `slot` \| ({ width, ...BasicLayoutProps }) => VNode                    | `false`            |
+| breadcrumbRender        | custom breadcrumb render method                                       | `slot` \| ({ route, params, routes, paths, h }) => VNode[]             | -                  |
 | locale                  | i18n                                                                  | Function (key: string) => string \| `false`                            | `false`            |
 
 > Menu generation requires `getMenuData` and `clearMenuItem` function
@@ -229,6 +231,38 @@ const layoutConf = reactive({
 <template #collapsedButtonRender="collapsed">
   <HeartOutlined v-if="collapsed" />
   <SmileOutlined v-else />
+</template>
+```
+
+#### Custom tabRender
+
+```vue
+<template #tabRender="{ width, fixedHeader }">
+  <div>
+    <header
+      class="ant-layout-header"
+      style="height: 36px; line-height: 36px; background: transparent"
+      v-if="fixedHeader"
+    ></header>
+    <div
+      :style="{
+        margin: '0',
+        height: '36px',
+        lineHeight: '36px',
+        right: '0px',
+        top: '48px',
+        position: fixedHeader ? 'fixed' : 'unset',
+        zIndex: 14,
+        padding: '4px 16px',
+        width: width,
+        background: '#fff',
+        boxShadow: '0 1px 4px #0015291f',
+        transition: 'background 0.3s, width 0.2s',
+      }"
+    >
+      tabRender fixedHeader：{{fixedHeader}} width：{{ width }} 
+    </div>
+  </div>
 </template>
 ```
 

--- a/packages/pro-layout/examples/router/index.ts
+++ b/packages/pro-layout/examples/router/index.ts
@@ -105,6 +105,12 @@ const routes: RouteRecordRaw[] = [
         ],
       },
       {
+        path: '/test-tab',
+        name: 'TestTab',
+        meta: { title: '测试Tab标签', hideInMenu: false },
+        component: () => import('../views/TestTab.vue'),
+      },
+      {
         path: 'https://next.antdv.com/',
         name: 'baidu_target',
         meta: { title: 'Ant Design Vue 官网', icon: 'link-outlined', target: '_blank' },

--- a/packages/pro-layout/examples/views/TestTab.vue
+++ b/packages/pro-layout/examples/views/TestTab.vue
@@ -1,0 +1,62 @@
+<template>
+  <PageContainer
+    :loading="loading"
+    fixed-header
+    :title="(route.meta.title as string)"
+    :tab-list="tabList"
+    :tab-active-key="tabActiveKey"
+    @tab-change="tabChange"
+    :tabProps="{
+      hideAdd: true,
+      tabPosition: 'top',
+      type: 'editable-card',
+      tabBarGutter: 8,
+      tabBarStyle: { margin: '0', height: '32px', lineHeight: '32px' },
+      onEdit: tabEdit,
+    }"
+  >
+    <template #tags>
+      <Tag>tag1</Tag>
+      <Tag color="pink">tag2</Tag>
+    </template>
+    <Result
+      status="info"
+      :style="{
+        height: '100%',
+      }"
+      title="show tabs"
+      sub-title="pro-layout可使用 tabRender 插槽自定义标签页"
+    >
+      <template #extra>
+        <Button type="primary">ME {{ tabActiveKey }}</Button>
+      </template>
+    </Result>
+  </PageContainer>
+</template>
+
+<script setup lang="ts">
+import { Button, Tag, Result } from "ant-design-vue";
+import { PageContainer } from "@ant-design-vue/pro-layout";
+
+import { useRoute } from "vue-router";
+import { reactive, ref } from "vue";
+
+const route = useRoute();
+
+let loading = ref<boolean>(false)
+let tabList = reactive(
+  Array.from({ length: 54 }, (_, i) => ({ key: "/tab" + i, tab: "tab" + i }))
+);
+let tabActiveKey = ref("/tab1");
+function tabChange(key: string) {
+  console.log("tabChange", key);
+  tabActiveKey.value = key;
+}
+function tabEdit(key: string) {
+  console.log("tabEdit", key);
+  loading.value = true
+  setTimeout(() => {
+    loading.value = false
+  }, 2000);
+}
+</script>

--- a/packages/pro-layout/src/BasicLayout.tsx
+++ b/packages/pro-layout/src/BasicLayout.tsx
@@ -34,6 +34,7 @@ import type {
   HeaderContentRender,
   HeaderRender,
   FooterRender,
+  TabRender,
   RightContentRender,
   MenuItemRender,
   SubMenuItemRender,
@@ -99,9 +100,7 @@ export const basicLayoutProps = {
   },
   breadcrumbRender: {
     type: [Object, Function, Boolean] as PropType<BreadcrumbRender>,
-    default() {
-      return null;
-    },
+    default: () => null,
   },
   headerContentRender: {
     type: [Function, Object, Boolean] as PropType<HeaderContentRender>,
@@ -113,6 +112,10 @@ export const basicLayoutProps = {
   },
   footerRender: {
     type: [Object, Function, Boolean] as PropType<FooterRender>,
+    default: () => undefined,
+  },
+  tabRender: {
+    type: [Object, Function, Boolean] as PropType<TabRender>,
     default: () => undefined,
   },
 };
@@ -259,7 +262,8 @@ const ProLayout = defineComponent({
       const rightContentRender = getSlot<RightContentRender>(slots, props, 'rightContentRender');
       const customHeaderRender = getSlot<HeaderRender>(slots, props, 'headerRender');
       const footerRender = getSlot<FooterRender>(slots, props, 'footerRender');
-
+      const tabRender = getSlot<TabRender>(slots, props, 'tabRender');
+      
       // menu
       const menuHeaderRender = getSlot<MenuHeaderRender>(slots, props, 'menuHeaderRender');
       const menuExtraRender = getSlot<MenuExtraRender>(slots, props, 'menuExtraRender');
@@ -294,8 +298,24 @@ const ProLayout = defineComponent({
         )
       );
 
+      const tabDom = computed(() => {
+        if (props.tabRender === false || !tabRender) {
+          return null;
+        }
+        let layout = props.layout;
+        let fixedHeader = props.fixedHeader;
+        // 计算侧边栏的宽度，不然导致左边的样式会出问题
+        let width = '100%';
+        if (layout === 'mix' && hasSplitMenu.value && flatMenuData.value.length === 0) {
+          width = '100%';
+        } else if(fixedHeader && !isTop.value && !isMobile.value){
+          width = `calc(100% - ${siderWidth.value}px)`;
+        }
+        return tabRender({ width, ...props });
+      });
+      
       routeContext.hasHeader = !!headerDom.value;
-
+      
       const contentClassName = computed(() => {
         return {
           [`${baseClassName.value}-content`]: true,
@@ -335,6 +355,7 @@ const ProLayout = defineComponent({
                 )}
                 <div style={genLayoutStyle} class={prefixCls.value}>
                   {headerDom.value}
+                  {tabDom.value}
                   <WrapContent
                     isChildrenLayout={props.isChildrenLayout}
                     class={contentClassName.value}

--- a/packages/pro-layout/src/RenderTypings.ts
+++ b/packages/pro-layout/src/RenderTypings.ts
@@ -8,6 +8,7 @@ export type BreadcrumbRender = BreadcrumbProps['itemRender'];
 export type HeaderContentRender = WithFalse<() => CustomRender>;
 export type HeaderRender = WithFalse<(props: ProProps) => CustomRender>;
 export type FooterRender = WithFalse<(props: ProProps) => CustomRender>;
+export type TabRender = WithFalse<(props: ProProps) => CustomRender>;
 export type RightContentRender = WithFalse<(props: ProProps) => CustomRender>;
 export type MenuItemRender = WithFalse<
   (args: { item: MenuDataItem; title?: JSX.Element; icon?: JSX.Element }) => CustomRender

--- a/packages/pro-layout/src/components/GlobalHeader/index.less
+++ b/packages/pro-layout/src/components/GlobalHeader/index.less
@@ -12,6 +12,7 @@
   align-items: center;
   height: 100%;
   padding: 0 16px;
+  color: @text-color;
   background: @pro-layout-header-bg;
   box-shadow: @pro-layout-header-box-shadow;
   > * {

--- a/packages/pro-layout/src/components/PageContainer/index.tsx
+++ b/packages/pro-layout/src/components/PageContainer/index.tsx
@@ -11,7 +11,7 @@ import {
 } from 'vue';
 /* replace antd ts define */
 import PageHeader, { pageHeaderProps } from 'ant-design-vue/es/page-header';
-import { Tabs, Affix, Spin } from 'ant-design-vue';
+import { Tabs, Affix } from 'ant-design-vue';
 import type { TabPaneProps } from './interfaces/TabPane';
 import type { TabBarExtraContent /*, TabsProps */ } from './interfaces/Tabs';
 import type { AffixProps } from './interfaces/Affix';
@@ -22,7 +22,7 @@ import 'ant-design-vue/es/affix/style';
 import 'ant-design-vue/es/page-header/style';
 import 'ant-design-vue/es/breadcrumb/style';
 import 'ant-design-vue/es/tabs/style';
-import 'ant-design-vue/es/spin/style';
+import PageLoading from '../PageLoading';
 import GridContent from '../GridContent';
 import FooterToolbar from '../FooterToolbar';
 import { withInstall } from 'ant-design-vue/es/_util/type';
@@ -291,7 +291,7 @@ const PageContainer = defineComponent({
           )}
           <GridContent>
             {loading.value ? (
-              <Spin />
+              <PageLoading />
             ) : slots.default ? (
               <div>
                 <div class={`${prefixedClassName.value}-children-content`}>{slots.default()}</div>

--- a/packages/pro-layout/src/components/TopNavHeader/index.less
+++ b/packages/pro-layout/src/components/TopNavHeader/index.less
@@ -8,12 +8,14 @@
   height: 100%;
   box-shadow: 0 1px 4px 0 rgba(0, 21, 41, 0.12);
   transition: background 0.3s, width 0.2s;
+  color: @text-color-dark;
 
   .@{ant-prefix}-menu {
     background: transparent;
   }
 
   &.light {
+    color: @text-color;
     background-color: @component-background;
     .@{top-nav-header-prefix-cls}-logo {
       h1 {


### PR DESCRIPTION
- PageContainer

容器内使用loading时，居中显示

- Header 

导航文字颜色根据Theme取反色，亮是黑色字体，暗是白色字体

- BasicLayout

新增Tab标签页自定义插槽

- examples

添加测试示例PageContainer对tab-list的使用