### PR TITLE
fix(isImg): 修复创建`<LazyIcon>`组件时，使用的`isImg`方法未检测图片资源是否为base64编码的问题

### DIFF
--- a/packages/pro-layout/src/utils/isImg/index.ts
+++ b/packages/pro-layout/src/utils/isImg/index.ts
@@ -1,8 +1,12 @@
 // source by https://github.com/ant-design/pro-components/blob/master/packages/utils/src/isImg/index.ts
 
+const imagePattern = 'png|jpg|jpeg|svg|webp|gif|bmp';
+const suffixPattern = new RegExp(`\\w.(${imagePattern})$`, 'i');
+const base64Pattern = new RegExp(`^data:image\\/(${imagePattern})`, 'i');
+
 /** 判断是否是图片链接 */
 function isImg(path: string): boolean {
-  return /\w.(png|jpg|jpeg|svg|webp|gif|bmp)$/i.test(path);
+  return suffixPattern.test(path) || base64Pattern.test(path);
 }
 
 export default isImg;

--- a/packages/utils/src/isImg/index.ts
+++ b/packages/utils/src/isImg/index.ts
@@ -1,8 +1,12 @@
 // source by https://github.com/ant-design/pro-components/blob/master/packages/utils/src/isImg/index.ts
 
+const imagePattern = 'png|jpg|jpeg|svg|webp|gif|bmp';
+const suffixPattern = new RegExp(`\\w.(${imagePattern})$`, 'i');
+const base64Pattern = new RegExp(`^data:image\\/(${imagePattern})`, 'i');
+
 /** 判断是否是图片链接 */
 function isImg(path: string): boolean {
-  return /\w.(png|jpg|jpeg|svg|webp|gif|bmp)$/i.test(path);
+  return suffixPattern.test(path) || base64Pattern.test(path);
 }
 
 export default isImg;


### PR DESCRIPTION
### **问题表述：**
在开启了Vite的构建选项`assetInlineLimit`时，小文件会被内联为base64编码，而原先`<LazyIcon>`组件使用的`isImg`工具函数在判断资源路径是否为图片类型时忽略了base64编码，这会导致小文件图片资源以base64编码进行内联时，组件创建异常的问题。
### **解决方法**
添加对于base64编码图片资源的识别，直接将其创建为`img`元素。